### PR TITLE
Adding cover page parameter

### DIFF
--- a/lib/wkhtmltopdf.js
+++ b/lib/wkhtmltopdf.js
@@ -37,6 +37,7 @@ var HtmlToPdf = function (reporter, definition) {
     pageSize: {type: "Edm.String"},
     pageHeight: {type: "Edm.String"},
     pageWidth: {type: "Edm.String"},
+    coverPage: {type:"Edm.String"},
     toc: {type: "Edm.Boolean"},
     tocHeaderText: {type: "Edm.String"},
     tocLevelIndentation: {type: "Edm.String"},
@@ -121,6 +122,11 @@ function createParams (request, options, id) {
     params.push("file:///" + path.join(request.reporter.options.tempDirectory, id + "footer.html"));
   }
 
+  if(options.coverPage){
+    params.push("cover");
+    params.push("file:///" + path.join(request.reporter.options.tempDirectory, id + "coverPage.html"));
+  }
+
   if (options.toc && JSON.parse(options.toc)) {
     params.push("toc");
 
@@ -162,7 +168,9 @@ function processPart (options, req, type, id) {
 
 function processHeaderAndFooter (options, req, id) {
   return processPart(options, req, "header", id).then(function () {
-    return processPart(options, req, "footer", id);
+    return processPart(options, req, "footer", id).then(function (){
+      return processPart(options, req, "coverPage", id);
+    });
   });
 }
 

--- a/public/templates/wkhtmltopdf-template.html
+++ b/public/templates/wkhtmltopdf-template.html
@@ -55,6 +55,8 @@
     <span class="side-title">Footer</span>
     <textarea class="form-control side-textarea" placeholder="footer content, !!!include <!DOCTYPE html>!!!" name="footer">{{:footer}}</textarea>
 
+    <span class="side-title">Cover Page</span>
+    <textarea class="form-control side-textarea" placeholder="Cover Page Content, !!!include <!DOCTYPE html>!!!" name="coverPage">{{:coverPage}}</textarea>
 
     <span class="side-title">Table Of Contents</span>
     <input type="checkbox" name="toc" checked="checked"/>


### PR DESCRIPTION
Working the same as the header/footer text fields this allows a user to input html into the cover page text area which would be rendered before the ToC and gets excluded from the ToC.
