### PR TITLE
added option maxBuffer for the reporter node

### DIFF
--- a/lib/wkhtmltopdf.js
+++ b/lib/wkhtmltopdf.js
@@ -17,6 +17,7 @@ var HtmlToPdf = function (reporter, definition) {
   this.reporter = reporter
   this.definition = definition
 
+  this.maxBuffer = reporter.options.hasOwnProperty('maxBuffer') ? reporter.options.maxBuffer : (1000 * 1024)
   this.allowLocalFilesAccess = definition.options.hasOwnProperty('allowLocalFilesAccess') ? definition.options.allowLocalFilesAccess : false
   this.wkhtmltopdfVersions = definition.options.wkhtmltopdfVersions = [{ version: wkhtmltopdf.version }]
 
@@ -261,9 +262,9 @@ HtmlToPdf.prototype.conversion = function (parameters, request) {
   }
 
   request.logger.debug('wkhtmltopdf  ' + parameters.join(' '))
-
+  var self = this;
   return new Promise(function (resolve, reject) {
-    childProcess.execFile(exePath, parameters, function (err, stderr, stdout) {
+    childProcess.execFile(exePath, parameters, {maxBuffer: self.maxBuffer}, function (err, stderr, stdout) {
       request.logger.debug((err || '') + (stderr || '') + (stdout || ''))
 
       if (err) {

--- a/lib/wkhtmltopdf.js
+++ b/lib/wkhtmltopdf.js
@@ -17,7 +17,7 @@ var HtmlToPdf = function (reporter, definition) {
   this.reporter = reporter
   this.definition = definition
 
-  this.maxBuffer = reporter.options.hasOwnProperty('maxBuffer') ? reporter.options.maxBuffer : (1000 * 1024)
+  this.maxBuffer = definition.options.hasOwnProperty('maxBuffer') ? definition.options.maxBuffer : (1000 * 1024)
   this.allowLocalFilesAccess = definition.options.hasOwnProperty('allowLocalFilesAccess') ? definition.options.allowLocalFilesAccess : false
   this.wkhtmltopdfVersions = definition.options.wkhtmltopdfVersions = [{ version: wkhtmltopdf.version }]
 
@@ -69,7 +69,7 @@ function createParams (reporter, request, options, definition, id) {
   }
 
   Object.keys(definition.options).forEach(function (k) {
-    if (k === 'allowLocalFilesAccess' || k === 'wkhtmltopdfVersions') {
+    if (k === 'allowLocalFilesAccess' || k === 'wkhtmltopdfVersions' || k === 'maxBuffer') {
       return
     }
 

--- a/lib/wkhtmltopdf.js
+++ b/lib/wkhtmltopdf.js
@@ -262,7 +262,7 @@ HtmlToPdf.prototype.conversion = function (parameters, request) {
   }
 
   request.logger.debug('wkhtmltopdf  ' + parameters.join(' '))
-  var self = this;
+  var self = this
   return new Promise(function (resolve, reject) {
     childProcess.execFile(exePath, parameters, {maxBuffer: self.maxBuffer}, function (err, stderr, stdout) {
       request.logger.debug((err || '') + (stderr || '') + (stdout || ''))


### PR DESCRIPTION
 That can be setted in dev/prod.config.js files
such as 
```
{
  ...
  "reporter": {
    "maxBuffer": 512000 // will allow a buffer size of 512Mb
  }
  ...
}
```